### PR TITLE
Fix software name in ATTRIBUTION_NOTICE

### DIFF
--- a/ATTRIBUTION_NOTICE
+++ b/ATTRIBUTION_NOTICE
@@ -1,4 +1,4 @@
-5G-MAG RT 5GMS Application Function uses the following open source software:
+5G-MAG RT 5G Data Collection Application Function uses the following open source software:
 
 - open5gs - Opensource 5G Core implementation
   available from https://open5gs.org/


### PR DESCRIPTION
Fixes the opening sentence in the attribution notice to indicate that the software is the Data Collection AF, not the 5GMS AF.

All the actual attributions are fine, so I don't think this necessitates another release and this change can wait until the next release.